### PR TITLE
https 적용, 포트 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# SSL Certification 
+cert/
 
 # Created by https://www.gitignore.io/api/node
 # Edit at https://www.gitignore.io/?templates=node

--- a/package-lock.json
+++ b/package-lock.json
@@ -788,11 +788,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -805,15 +807,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -916,7 +921,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -926,6 +932,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -938,17 +945,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -965,6 +975,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1037,7 +1048,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1047,6 +1059,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1152,6 +1165,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon server.js"
+    "start": "NODE_ENV=production nodemon server.js",
+    "debug": "NODE_ENV=development nodemon server.js"	
   },
   "author": "goodri",
   "license": "MIT",

--- a/server.js
+++ b/server.js
@@ -1,8 +1,20 @@
 const http = require('http');
+const https = require('https');
+const fs = require('fs');
 const app = require('./app');
 
-const port = process.env.PORT || 3000;
+const PORT = process.env.PORT || 2083;
+const CREDENTIAL_CERT_PATH = './cert/nyam.deerwhite.net.pem';
+const CREDENTIAL_KEY_PATH = './cert/nyam.deerwhite.net.key';
 
-const server = http.createServer(app);
+const credentials = {
+	cert: fs.readFileSync(CREDENTIAL_CERT_PATH, 'utf8'),
+	key: fs.readFileSync(CREDENTIAL_KEY_PATH, 'utf8')
+};
 
-server.listen(port);
+console.log(`NODE_ENV: ${process.env.NODE_ENV}`);
+console.log(`Server start listening on port ${PORT}`);
+
+const server = (process.env.NODE_ENV === 'development')? http.createServer(app) : https.createServer(credentials, app);
+
+server.listen(PORT);


### PR DESCRIPTION
### 작업사항
- Production, Development 분리
    - Production에서는 https 적용
    - 개발 중 로컬에서는 http로 동작
- 기본 포트 3000 -> 2083 변경

### Production
- https 프로토콜 사용
- `npm start` or `npm run start`

### Development
- http 프로토콜 사용
- `npm run debug`

### 기타
- 인증서는 별도로 공유
